### PR TITLE
Add given gifts to database at start of day

### DIFF
--- a/GiftTasteHelper/GiftTasteHelper.cs
+++ b/GiftTasteHelper/GiftTasteHelper.cs
@@ -202,6 +202,30 @@ namespace GiftTasteHelper
         /// <param name="e">The event data.</param>
         private void OnDayStarted(object sender, DayStartedEventArgs e)
         {
+            var giftedItems = Game1.player.giftedItems;
+            Utility.ForEachVillager(npc =>
+            {
+                Utils.DebugLog("Rebuilding gift database");
+
+                if (!giftedItems.ContainsKey(npc.Name))
+                {
+                    // you haven't given this person any gifts
+                    return true;
+                }
+
+                var giftedItemIds = giftedItems[npc.Name].Keys;
+                foreach (var giftedItemId in giftedItemIds)
+                {
+                    var taste = Utils.GetTasteForGift(npc.Name, giftedItemId);
+                    if (taste != GiftTaste.MAX)
+                    {
+                        this.GiftDatabase.AddGift(npc.Name, giftedItemId, taste);
+                    }
+                }
+
+                return true;
+            });
+
             if (Game1.dayOfMonth == 1 && this.GiftHelpers.ContainsKey(typeof(Billboard)))
             {
                 // Reset the birthdays when season changes


### PR DESCRIPTION
As a fix for #5, at the start of each day, we iterate through the villagers and add any gifts that the player has already given.

I noticed that a few gifts aren't populating in the DB correctly (an example being Diamond for Evelyn). I don't know if that's caused by a problem with this PR or if it's related to categories (which I've seen aren't handled in a few places).